### PR TITLE
Remove redundant bigarray dependency

### DIFF
--- a/lib_lwt/dune
+++ b/lib_lwt/dune
@@ -1,5 +1,5 @@
 (library
  (name multipart_form_lwt)
  (public_name multipart_form-lwt)
- (libraries bigstringaf bigarray bigarray-compat result angstrom
+ (libraries bigstringaf bigarray-compat result angstrom
    multipart_form lwt ke))


### PR DESCRIPTION
Thanks for the library :)) 

This PR removes the extra `bigarray` dependency in the `lwt` library given there's a dependency on `bigarray-compat`. In OCaml 5.0.0+trunk the [findlib package for bigarray](https://github.com/ocaml/ocaml/pull/10896) has been removed so the library fails to build. 