### PR TITLE
Basic Eio wrapper

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,2 @@
 (lang dune 2.0)
 (name multipart_form)
-(implicit_transitive_deps false)

--- a/lib_eio/dune
+++ b/lib_eio/dune
@@ -1,0 +1,4 @@
+(library
+ (name multipart_form_eio)
+ (public_name multipart_form-eio)
+ (libraries bigstringaf angstrom multipart_form unix eio ke))

--- a/lib_eio/dune
+++ b/lib_eio/dune
@@ -1,4 +1,4 @@
 (library
  (name multipart_form_eio)
  (public_name multipart_form-eio)
- (libraries bigstringaf angstrom multipart_form unix eio ke))
+ (libraries bigstringaf angstrom multipart_form eio ke))

--- a/lib_eio/multipart_form_eio.ml
+++ b/lib_eio/multipart_form_eio.ml
@@ -28,8 +28,7 @@ let stream ~sw ?(bounds = 10) ~identify stream content_type =
         Eio.Stream.add stream data;
         go ()
     | `Data (_, None) ->
-        (* let _, stream = Hashtbl.find tbl id in *)
-        (* stream#close; *)
+      (* We do not need to manually close the stream as eio takes care of it for us *)
         go ()
     | exception Queue.Empty -> (
         (* otherwise, continue parsing (thus adding elements to the queue) *)

--- a/lib_eio/multipart_form_eio.ml
+++ b/lib_eio/multipart_form_eio.ml
@@ -1,0 +1,80 @@
+open Multipart_form
+
+let stream ~sw ?(bounds = 10) ~identify stream content_type =
+  let output = Eio.Stream.create max_int in
+  let q = Queue.create () in
+  let fresh_id =
+    let r = ref 0 in
+    fun () ->
+      incr r ;
+      !r in
+  let tbl = Hashtbl.create 0x10 in
+  let emitters header =
+    let id = fresh_id () in
+    Queue.push (`Id (header, id)) q ;
+    ((fun data -> Queue.push (`Data (id, data)) q), id) in
+  let parse = Multipart_form.parse ~emitters content_type in
+  let promise, resolve = Eio.Promise.create () in
+  let rec go () =
+    match Queue.pop q with
+    | `Id (header, id) ->
+        let client_id = identify header in
+        let stream = Eio.Stream.create bounds in
+        Hashtbl.add tbl id (client_id, stream) ;
+        Eio.Stream.add output (client_id, header, stream);
+        go ()
+    | `Data (id, Some data) ->
+        let _, stream = Hashtbl.find tbl id in
+        Eio.Stream.add stream data;
+        go ()
+    | `Data (_, None) ->
+        (* let _, stream = Hashtbl.find tbl id in *)
+        (* stream#close; *)
+        go ()
+    | exception Queue.Empty -> (
+        (* otherwise, continue parsing (thus adding elements to the queue) *)
+        let data = match Eio.Stream.take stream with Some s -> `String s | None -> `Eof in
+        match parse data with
+        | `Continue -> go ()
+        | `Done t ->
+            let client_id_of_id id =
+              let client_id, _ = Hashtbl.find tbl id in
+              client_id in
+            Eio.Promise.resolve_ok resolve (map client_id_of_id t)
+        | `Fail _ ->
+            Eio.Promise.resolve_error resolve (`Msg "Invalid multipart/form"))
+  in
+  Eio.Fiber.fork ~sw go;
+  (promise, output)
+
+(* only used internally to implement of_stream_to_{tree,list} *)
+let of_stream_to_tbl s content_type =
+  let identify =
+    let id = ref (-1) in
+    fun _header ->
+      incr id ;
+      !id in
+  Eio.Switch.run @@ fun sw ->
+  let t, parts = stream ~sw ~identify s content_type in
+  let parts_tbl = Hashtbl.create 0x10 in
+  let consume_part (id, _, part_stream) =
+    Eio.Stream.take part_stream
+    |> Hashtbl.add parts_tbl id
+  in
+  Eio.Fiber.fork ~sw (fun () ->
+      while not @@ Eio.Stream.is_empty parts do
+        Eio.Stream.take parts |> consume_part
+      done);
+  Eio.Promise.await t
+  |> Result.map (fun tree -> (tree, parts_tbl))
+
+let of_stream_to_tree s content_type =
+  of_stream_to_tbl s content_type
+  |> Result.map (fun (tree, parts_tbl) -> map (Hashtbl.find parts_tbl) tree)
+
+let of_stream_to_list s content_type =
+  of_stream_to_tbl s content_type
+  |> Result.map
+    (fun (tree, parts_tbl) ->
+       let assoc = Hashtbl.fold (fun k b a -> (k, b) :: a) parts_tbl [] in
+       (tree, assoc))

--- a/lib_eio/multipart_form_eio.mli
+++ b/lib_eio/multipart_form_eio.mli
@@ -6,7 +6,7 @@ val stream :
   sw:Eio.Switch.t ->
   ?bounds:int ->
   identify:(Header.t -> 'id) ->
-  string option Eio.Stream.t ->
+  string Eio.Stream.t ->
   Content_type.t ->
   ('id t, [> `Msg of string ]) result Eio.Promise.t
   * ('id * Header.t * string Eio.Stream.t) Eio.Stream.t
@@ -47,14 +47,14 @@ val stream :
     and therefore should not be used when handling possibly large data. *)
 
 val of_stream_to_list :
-  string option Eio.Stream.t ->
+  string Eio.Stream.t ->
   Content_type.t ->
   (int t * (int * string) list, [> `Msg of string ]) result
 (** Similar to [Multipart_form.of_stream_to_list], but consumes a
    [Lwt_stream.t]. *)
 
 val of_stream_to_tree :
-  string option Eio.Stream.t ->
+  string Eio.Stream.t ->
   Content_type.t ->
   (string t, [> `Msg of string ]) result
 (** [of_stream_to_tree stream content_type] returns, if it succeeds, a value

--- a/lib_eio/multipart_form_eio.mli
+++ b/lib_eio/multipart_form_eio.mli
@@ -1,0 +1,63 @@
+open Multipart_form
+
+(** {3 Streaming API.} *)
+
+val stream :
+  sw:Eio.Switch.t ->
+  ?bounds:int ->
+  identify:(Header.t -> 'id) ->
+  string option Eio.Stream.t ->
+  Content_type.t ->
+  ('id t, [> `Msg of string ]) result Eio.Promise.t
+  * ('id * Header.t * string Eio.Stream.t) Eio.Stream.t
+(** [stream ~identify src content_type] returns:
+    - a promise [th] about the parser
+    - a stream [stream] of parts
+
+    They can be manipulated with [Lwt.both], and, by this way,
+    ensure a real stream between the parser [th] and the process
+    which saves parts.
+
+    Assume that you have a function to save a [Lwt_stream.t] into
+    a [filename]:
+    {[
+      val save_part : filename:string -> Header.t -> string Lwt_stream.t ->
+        unit Lwt.t
+    ]}
+
+    You can use it with [stream] like:
+    {[
+      let identify _ : string = random_unique_filename () in
+      let `Parse th, stream = stream ~identify src content_type in
+      let rec saves () = Lwt_stream.get stream >>= function
+        | None -> Lwt.return_unit
+        | Some (filename, hdr, contents) ->
+          save_part ~filename hdr contents >>= fun () ->
+          saves () in
+      Lwt.both th (saves ()) >>= fun (res, ()) -> Lwt.return res
+    ]}
+
+    By this way, as long as we parse [src], at the same time, we save parts
+    into filenames. Finally, we return the [multipart/form] structure with
+    a mapping between temporary files and parts. *)
+
+(** {3 Non-streaming API.}
+
+    These functions will store the entire multipart contents in memory,
+    and therefore should not be used when handling possibly large data. *)
+
+val of_stream_to_list :
+  string option Eio.Stream.t ->
+  Content_type.t ->
+  (int t * (int * string) list, [> `Msg of string ]) result
+(** Similar to [Multipart_form.of_stream_to_list], but consumes a
+   [Lwt_stream.t]. *)
+
+val of_stream_to_tree :
+  string option Eio.Stream.t ->
+  Content_type.t ->
+  (string t, [> `Msg of string ]) result
+(** [of_stream_to_tree stream content_type] returns, if it succeeds, a value
+   {!Multipart_form.t} representing the multipart document, where the contents of the parts are
+   stored as strings. It is equivalent to [of_stream_to_list] where references
+   have been replaced with their associated contents. *)

--- a/multipart_form-eio.opam
+++ b/multipart_form-eio.opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Multipart-form: RFC2183, RFC2388 & RFC7578"
+description: """\
+Implementation of RFC7578 in OCaml
+
+Returning values from forms: multipart/form-data"""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/multipart_form"
+doc: "https://dinosaure.github.io/multipart_form/"
+bug-reports: "https://github.com/dinosaure/multipart_form/issues"
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "2.0.0"}
+  "angstrom"
+  "bigstringaf"
+  "eio"
+  "eio_main"
+  "ke"
+  "multipart_form" {= version}
+  "alcotest" {with-test}
+  "fmt" {with-test}
+  "rosetta" {with-test}
+  "rresult" {with-test}
+  "unstrctrd" {with-test}
+  "logs" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/multipart_form.git"

--- a/test/dune
+++ b/test/dune
@@ -10,6 +10,12 @@
  (libraries fmt fmt.tty logs logs.fmt alcotest alcotest-lwt lwt
    multipart_form multipart_form-lwt))
 
+(executable
+ (name test_eio)
+ (modules test_eio)
+ (libraries fmt fmt.tty logs logs.fmt alcotest eio
+   multipart_form multipart_form-eio))
+
 (rule
  (alias runtest)
  (package multipart_form)

--- a/test/dune
+++ b/test/dune
@@ -13,7 +13,7 @@
 (executable
  (name test_eio)
  (modules test_eio)
- (libraries fmt fmt.tty logs logs.fmt alcotest eio
+ (libraries fmt fmt.tty logs logs.fmt alcotest eio eio_main
    multipart_form multipart_form-eio))
 
 (rule

--- a/test/dune
+++ b/test/dune
@@ -10,11 +10,11 @@
  (libraries fmt fmt.tty logs logs.fmt alcotest alcotest-lwt lwt
    multipart_form multipart_form-lwt))
 
-(executable
- (name test_eio)
- (modules test_eio)
- (libraries fmt fmt.tty logs logs.fmt alcotest eio_main multipart_form
-   multipart_form-eio))
+; (executable
+;  (name test_eio)
+;  (modules test_eio)
+;  (libraries fmt fmt.tty logs logs.fmt alcotest eio_main multipart_form
+;    multipart_form-eio))
 
 (rule
  (alias runtest)
@@ -32,10 +32,10 @@
  (action
   (run %{test} --color=always)))
 
-(rule
- (alias runtest)
- (package multipart_form-eio)
- (deps
-  (:test test_eio.exe))
- (action
-  (run %{test} --color=always)))
+; (rule
+;  (alias runtest)
+;  (package multipart_form-eio)
+;  (deps
+;   (:test test_eio.exe))
+;  (action
+;   (run %{test} --color=always)))

--- a/test/dune
+++ b/test/dune
@@ -1,17 +1,41 @@
-(test
+(executable
  (name test)
  (modules test)
  (libraries rosetta unstrctrd unstrctrd.parser alcotest fmt rresult result
    angstrom multipart_form))
 
-(test
+(executable
  (name test_lwt)
  (modules test_lwt)
  (libraries fmt fmt.tty logs logs.fmt alcotest alcotest-lwt lwt
    multipart_form multipart_form-lwt))
 
-(test
+(executable
  (name test_eio)
  (modules test_eio)
- (libraries fmt fmt.tty logs logs.fmt alcotest eio eio_main
+ (libraries fmt fmt.tty logs logs.fmt alcotest eio
    multipart_form multipart_form-eio))
+
+(rule
+ (alias runtest)
+ (package multipart_form)
+ (deps
+  (:test test.exe))
+ (action
+  (run %{test} --color=always)))
+
+(rule
+ (alias runtest)
+ (package multipart_form-lwt)
+ (deps
+  (:test test_lwt.exe))
+ (action
+  (run %{test} --color=always)))
+
+(rule
+ (alias runtest)
+ (package multipart_form-eio)
+ (deps
+  (:test test_eio.exe))
+ (action
+  (run %{test} --color=always)))

--- a/test/dune
+++ b/test/dune
@@ -13,7 +13,7 @@
 (executable
  (name test_eio)
  (modules test_eio)
- (libraries fmt fmt.tty logs logs.fmt alcotest eio
+ (libraries fmt fmt.tty logs logs.fmt alcotest eio_main
    multipart_form multipart_form-eio))
 
 (rule

--- a/test/dune
+++ b/test/dune
@@ -1,33 +1,17 @@
-(executable
+(test
  (name test)
  (modules test)
  (libraries rosetta unstrctrd unstrctrd.parser alcotest fmt rresult result
    angstrom multipart_form))
 
-(executable
+(test
  (name test_lwt)
  (modules test_lwt)
  (libraries fmt fmt.tty logs logs.fmt alcotest alcotest-lwt lwt
    multipart_form multipart_form-lwt))
 
-(executable
+(test
  (name test_eio)
  (modules test_eio)
  (libraries fmt fmt.tty logs logs.fmt alcotest eio eio_main
    multipart_form multipart_form-eio))
-
-(rule
- (alias runtest)
- (package multipart_form)
- (deps
-  (:test test.exe))
- (action
-  (run %{test} --color=always)))
-
-(rule
- (alias runtest)
- (package multipart_form-lwt)
- (deps
-  (:test test_lwt.exe))
- (action
-  (run %{test} --color=always)))

--- a/test/dune
+++ b/test/dune
@@ -13,8 +13,8 @@
 (executable
  (name test_eio)
  (modules test_eio)
- (libraries fmt fmt.tty logs logs.fmt alcotest eio_main
-   multipart_form multipart_form-eio))
+ (libraries fmt fmt.tty logs logs.fmt alcotest eio_main multipart_form
+   multipart_form-eio))
 
 (rule
  (alias runtest)

--- a/test/test_eio.ml
+++ b/test/test_eio.ml
@@ -1,0 +1,100 @@
+let reporter ppf =
+  let report src level ~over k msgf =
+    let k _ =
+      over () ;
+      k () in
+    let with_metadata header _tags k ppf fmt =
+      Format.kfprintf k ppf
+        ("[%a]%a[%a]: " ^^ fmt ^^ "\n%!")
+        Fmt.(styled `Blue int)
+        (Unix.getpid ()) Logs_fmt.pp_header (level, header)
+        Fmt.(styled `Magenta string)
+        (Logs.Src.name src) in
+    msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt in
+  { Logs.report }
+
+let () = Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true ()
+let () = Logs.set_reporter (reporter Fmt.stderr)
+let () = Logs.set_level ~all:true (Some Logs.Debug)
+
+let truncated_request01 =
+  {|--------------------------eb790219f130e103
+Content-Disposition: form-data; name="text"
+
+default
+--------------------------eb790219f130e103
+Content-Disposition: form-data; name="file1"; filename="a.html"
+Content-Type: text/html
+
+<!DOCTYPE html><title>Content of a.html.</title>
+
+--------------------------eb790219f130e103
+Content-Disposition: form-data; name="file2"; filename="a.txt"
+Content-Type: text/plain
+
+Conten|}
+
+let truncated_request02 =
+  {|--------------------------eb790219f130e103
+Content-Disposition: form-data; name="text"
+
+default
+--------------------------eb790219f130e103
+Content-Disposition: form-data; name="file1"; filename="a.html"
+Content-Type: text/html
+
+<!DOCTYPE html><title>Content of a.html.</title>
+
+--------------------------eb790219f130e103
+Content-Disposition: form-data; name="file2"; filename="a.txt"
+Content-Type: text/plain
+
+Conten|}
+
+open Lwt.Infix
+
+let always v _ = v
+
+let test01 =
+  Alcotest_lwt.test_case "truncated flow (with CRLF)" `Quick
+  @@ fun _switch () ->
+  let content_type =
+    "multipart/form-data; boundary=------------------------eb790219f130e103\r\n"
+  in
+  let content_type =
+    match Multipart_form.Content_type.of_string content_type with
+    | Ok v -> v
+    | Error (`Msg err) -> failwith err in
+  let body = Lwt_stream.return truncated_request01 in
+  let `Parse th, _ =
+    Multipart_form_lwt.stream ~identify:(always ()) body content_type in
+  th >>= function
+  | Ok _ ->
+      Alcotest.(check pass) "Truncated request" () () ;
+      Lwt.return_unit
+  | Error (`Msg err) -> Alcotest.failf "Unexpected error: %s" err
+
+let test02 =
+  Alcotest_lwt.test_case "truncated flow (without CRLF)" `Quick
+  @@ fun _switch () ->
+  let content_type =
+    "multipart/form-data; boundary=------------------------eb790219f130e103\r\n"
+  in
+  let content_type =
+    match Multipart_form.Content_type.of_string content_type with
+    | Ok v -> v
+    | Error (`Msg err) -> failwith err in
+  let body = Lwt_stream.return truncated_request02 in
+  let `Parse th, _ =
+    Multipart_form_lwt.stream ~identify:(always ()) body content_type in
+  th >>= function
+  | Ok _ -> Alcotest.fail "Unexpected valid input"
+  | Error (`Msg "Invalid multipart/form") ->
+      Alcotest.(check pass) "truncated input" () () ;
+      Lwt.return_unit
+  | Error (`Msg err) -> Alcotest.failf "Unexpected error: %s." err
+
+let th =
+  Alcotest_lwt.run "multipart_form_lwt" [ ("truncated", [ test01; test02 ]) ]
+
+let () = Lwt_main.run th

--- a/test/test_eio.ml
+++ b/test/test_eio.ml
@@ -54,36 +54,9 @@ Conten|}
 let always v _ = v
 
 let test01 =
-  Alcotest.test_case "truncated flow (with CRLF)" `Quick
-  @@ fun _ -> Eio_main.run
-  @@ fun _ -> Eio.Switch.run
-  @@ fun sw ->
-  let content_type =
-    "multipart/form-data; boundary=------------------------eb790219f130e103\r\n"
-  in
-  let content_type =
-    match Multipart_form.Content_type.of_string content_type with
-    | Ok v -> v
-    | Error (`Msg err) -> failwith err
-  in
-  let body = Eio.Stream.create max_int in
-  Eio.Stream.add body truncated_request01;
-  let th =
-    Multipart_form_eio.stream ~sw ~identify:(always ()) body content_type
-    |> fst
-    |> Eio.Promise.await_exn
-  in
-  Printf.printf "Got till promise!\n%!";
-  match th with
-  | Ok _ ->
-      Alcotest.(check pass) "Truncated request" () ()
-  | Error (`Msg err) -> Alcotest.failf "Unexpected error: %s" err
-
-let test02 =
-  Alcotest.test_case "truncated flow (without CRLF)" `Quick
-  @@ fun _ -> Eio_main.run
-  @@ fun _ -> Eio.Switch.run
-  @@ fun sw ->
+  Alcotest.test_case "truncated flow (with CRLF)" `Quick @@ fun _ ->
+  Eio_main.run @@ fun _ ->
+  Eio.Switch.run @@ fun sw ->
   let content_type =
     "multipart/form-data; boundary=------------------------eb790219f130e103\r\n"
   in
@@ -92,17 +65,37 @@ let test02 =
     | Ok v -> v
     | Error (`Msg err) -> failwith err in
   let body = Eio.Stream.create max_int in
-  Eio.Stream.add body truncated_request02;
+  Eio.Stream.add body truncated_request01 ;
   let th =
     Multipart_form_eio.stream ~sw ~identify:(always ()) body content_type
     |> fst
-    |> Eio.Promise.await_exn
+    |> Eio.Promise.await_exn in
+  Printf.printf "Got till promise!\n%!" ;
+  match th with
+  | Ok _ -> Alcotest.(check pass) "Truncated request" () ()
+  | Error (`Msg err) -> Alcotest.failf "Unexpected error: %s" err
+
+let test02 =
+  Alcotest.test_case "truncated flow (without CRLF)" `Quick @@ fun _ ->
+  Eio_main.run @@ fun _ ->
+  Eio.Switch.run @@ fun sw ->
+  let content_type =
+    "multipart/form-data; boundary=------------------------eb790219f130e103\r\n"
   in
+  let content_type =
+    match Multipart_form.Content_type.of_string content_type with
+    | Ok v -> v
+    | Error (`Msg err) -> failwith err in
+  let body = Eio.Stream.create max_int in
+  Eio.Stream.add body truncated_request02 ;
+  let th =
+    Multipart_form_eio.stream ~sw ~identify:(always ()) body content_type
+    |> fst
+    |> Eio.Promise.await_exn in
   match th with
   | Ok _ -> Alcotest.fail "Unexpected valid input"
   | Error (`Msg "Invalid multipart/form") ->
       Alcotest.(check pass) "truncated input" () ()
   | Error (`Msg err) -> Alcotest.failf "Unexpected error: %s." err
 
-let () =
-  Alcotest.run "multipart_form_eio" [ ("truncated", [ test01; test02]) ]
+let () = Alcotest.run "multipart_form_eio" [ ("truncated", [ test01; test02 ]) ]

--- a/test/test_eio.ml
+++ b/test/test_eio.ml
@@ -71,9 +71,10 @@ let test01 =
   let th =
     Multipart_form_eio.stream ~sw ~identify:(always ()) body content_type
     |> fst
+    |> Eio.Promise.await_exn
   in
   Printf.printf "Got till promise!\n%!";
-  match Eio.Promise.await th with
+  match th with
   | Ok _ ->
       Alcotest.(check pass) "Truncated request" () ()
   | Error (`Msg err) -> Alcotest.failf "Unexpected error: %s" err
@@ -95,7 +96,7 @@ let test02 =
   let th =
     Multipart_form_eio.stream ~sw ~identify:(always ()) body content_type
     |> fst
-    |> Eio.Promise.await
+    |> Eio.Promise.await_exn
   in
   match th with
   | Ok _ -> Alcotest.fail "Unexpected valid input"


### PR DESCRIPTION
This PR ports the Lwt wrapper to Eio, thereby providing a nicer interface for those using Eio. The code structure is still quite similar, it could likely be written more compactly.

I've also written a test and used it a bit so the code is at least mostly correct. I have not tested it extensively so an infinite wait is in theory possible.

Unrelated changes in the PR:
- In the dune-project file `(implicit_transitive_deps false)` caused some issues and after finding that it is an experimental feature I removed it. Is there a reason for its existence?
- I changed the "executables" in `test/` into actual tests in the dune file. Is there a reason this hasn't been done or is it legacy?