### PR TITLE
Fix the tests with OCaml 5.2

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -29,50 +29,50 @@ let parser ~emitters =
  * echo "<!DOCTYPE html><title>Content of a.html.</title>" > a.html
  * curl -F "text=default" -F "file1=@a.html" -F "file2=@a.txt" localhost:8000 *)
 let simple =
-  {html|Host: localhost:8000
-User-Agent: curl/7.47.0
-Accept: */*
-Content-Length: 489
-Expect: 100-continue
-Content-Type: multipart/form-data; boundary=------------------------eb790219f130e103
-
---------------------------eb790219f130e103
-Content-Disposition: form-data; name="text"
-
-default
---------------------------eb790219f130e103
-Content-Disposition: form-data; name="file1"; filename="a.html"
-Content-Type: text/html
-
+  {html|Host: localhost:8000|html}^"\r"^{html|
+User-Agent: curl/7.47.0|html}^"\r"^{html|
+Accept: */*|html}^"\r"^{html|
+Content-Length: 489|html}^"\r"^{html|
+Expect: 100-continue|html}^"\r"^{html|
+Content-Type: multipart/form-data; boundary=------------------------eb790219f130e103|html}^"\r"^{html|
+|html}^"\r"^{html|
+--------------------------eb790219f130e103|html}^"\r"^{html|
+Content-Disposition: form-data; name="text"|html}^"\r"^{html|
+|html}^"\r"^{html|
+default|html}^"\r"^{html|
+--------------------------eb790219f130e103|html}^"\r"^{html|
+Content-Disposition: form-data; name="file1"; filename="a.html"|html}^"\r"^{html|
+Content-Type: text/html|html}^"\r"^{html|
+|html}^"\r"^{html|
 <!DOCTYPE html><title>Content of a.html.</title>
-
---------------------------eb790219f130e103
-Content-Disposition: form-data; name="file2"; filename="a.txt"
-Content-Type: text/plain
-
+|html}^"\r"^{html|
+--------------------------eb790219f130e103|html}^"\r"^{html|
+Content-Disposition: form-data; name="file2"; filename="a.txt"|html}^"\r"^{html|
+Content-Type: text/plain|html}^"\r"^{html|
+|html}^"\r"^{html|
 Content of a.txt.
-
---------------------------eb790219f130e103--
+|html}^"\r"^{html|
+--------------------------eb790219f130e103--|html}^"\r"^{html|
 |html}
 
 let simple_without_header =
-  {html|--------------------------eb790219f130e103
-Content-Disposition: form-data; name="text"
-
-default
---------------------------eb790219f130e103
-Content-Disposition: form-data; name="file1"; filename="a.html"
-Content-Type: text/html
-
+  {html|--------------------------eb790219f130e103|html}^"\r"^{html|
+Content-Disposition: form-data; name="text"|html}^"\r"^{html|
+|html}^"\r"^{html|
+default|html}^"\r"^{html|
+--------------------------eb790219f130e103|html}^"\r"^{html|
+Content-Disposition: form-data; name="file1"; filename="a.html"|html}^"\r"^{html|
+Content-Type: text/html|html}^"\r"^{html|
+|html}^"\r"^{html|
 <!DOCTYPE html><title>Content of a.html.</title>
-
---------------------------eb790219f130e103
-Content-Disposition: form-data; name="file2"; filename="a.txt"
-Content-Type: text/plain
-
+|html}^"\r"^{html|
+--------------------------eb790219f130e103|html}^"\r"^{html|
+Content-Disposition: form-data; name="file2"; filename="a.txt"|html}^"\r"^{html|
+Content-Type: text/plain|html}^"\r"^{html|
+|html}^"\r"^{html|
 Content of a.txt.
-
---------------------------eb790219f130e103--
+|html}^"\r"^{html|
+--------------------------eb790219f130e103--|html}^"\r"^{html|
 |html}
 
 module Map = Map.Make (String)
@@ -262,22 +262,22 @@ let content_type_2 =
   Rresult.R.get_ok value
 
 let contents =
-  {multipart|
------------------------------11410681503802810592492044004
-Content-Disposition: form-data; name="dream.csrf"
-
-foobar
------------------------------11410681503802810592492044004
-Content-Disposition: form-data; name="files"; filename="a b.txt"
-Content-Type: text/plain
-
-1234
------------------------------11410681503802810592492044004
-Content-Disposition: form-data; name="files"; filename="a b.txt"
-Content-Type: text/plain
-
-4321
------------------------------11410681503802810592492044004--
+  "\r"^{multipart|
+-----------------------------11410681503802810592492044004|multipart}^"\r"^{multipart|
+Content-Disposition: form-data; name="dream.csrf"|multipart}^"\r"^{multipart|
+|multipart}^"\r"^{multipart|
+foobar|multipart}^"\r"^{multipart|
+-----------------------------11410681503802810592492044004|multipart}^"\r"^{multipart|
+Content-Disposition: form-data; name="files"; filename="a b.txt"|multipart}^"\r"^{multipart|
+Content-Type: text/plain|multipart}^"\r"^{multipart|
+|multipart}^"\r"^{multipart|
+1234|multipart}^"\r"^{multipart|
+-----------------------------11410681503802810592492044004|multipart}^"\r"^{multipart|
+Content-Disposition: form-data; name="files"; filename="a b.txt"|multipart}^"\r"^{multipart|
+Content-Type: text/plain|multipart}^"\r"^{multipart|
+|multipart}^"\r"^{multipart|
+4321|multipart}^"\r"^{multipart|
+-----------------------------11410681503802810592492044004--|multipart}^"\r"^{multipart|
 |multipart}
 
 let filename_with_space =

--- a/test/test_lwt.ml
+++ b/test/test_lwt.ml
@@ -18,20 +18,20 @@ let () = Logs.set_reporter (reporter Fmt.stderr)
 let () = Logs.set_level ~all:true (Some Logs.Debug)
 
 let truncated_request01 =
-  {|--------------------------eb790219f130e103
-Content-Disposition: form-data; name="text"
-
-default
---------------------------eb790219f130e103
-Content-Disposition: form-data; name="file1"; filename="a.html"
-Content-Type: text/html
-
-<!DOCTYPE html><title>Content of a.html.</title>
-
---------------------------eb790219f130e103
-Content-Disposition: form-data; name="file2"; filename="a.txt"
-Content-Type: text/plain
-
+  {|--------------------------eb790219f130e103|}^"\r"^{|
+Content-Disposition: form-data; name="text"|}^"\r"^{|
+|}^"\r"^{|
+default|}^"\r"^{|
+--------------------------eb790219f130e103|}^"\r"^{|
+Content-Disposition: form-data; name="file1"; filename="a.html"|}^"\r"^{|
+Content-Type: text/html|}^"\r"^{|
+|}^"\r"^{|
+<!DOCTYPE html><title>Content of a.html.</title>|}^"\r"^{|
+|}^"\r"^{|
+--------------------------eb790219f130e103|}^"\r"^{|
+Content-Disposition: form-data; name="file2"; filename="a.txt"|}^"\r"^{|
+Content-Type: text/plain|}^"\r"^{|
+|}^"\r"^{|
 Conten|}
 
 let truncated_request02 =


### PR DESCRIPTION
Same as https://github.com/mirage/mrmime/pull/99, https://github.com/mirage/pecu/pull/14 and https://github.com/dinosaure/unstrctrd/pull/17
```
#=== ERROR while compiling multipart_form.0.5.0 ===============================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/multipart_form.0.5.0
# command              ~/.opam/5.2/bin/dune runtest -p multipart_form -j 1
# exit-code            1
# env-file             ~/.opam/log/multipart_form-1594-240fcf.env
# output-file          ~/.opam/log/multipart_form-1594-240fcf.out
### output ###
# File "test/dune", line 13, characters 0-117:
# 13 | (rule
# 14 |  (alias runtest)
# 15 |  (package multipart_form)
# 16 |  (deps
# 17 |   (:test test.exe))
# 18 |  (action
# 19 |   (run %{test} --color=always)))
# (cd _build/default/test && ./test.exe --color=always)
# Testing `multipart_form'.
# This run has ID `F4MR7GX6'.
# 
#   [OK]          content-type                      0   text/plain; charset=us-...
#   [OK]          content-type                      1   text/plain; charset="us...
#   [OK]          content-type                      2   text/plain; charset=ISO...
# > [FAIL]        multipart_form (decoder)          0   simple.
#   [FAIL]        multipart_form (decoder)          1   simple with helpers.
#   [OK]          multipart_form (encoder)          0   simple.
#   [FAIL]        filename with space               0   filename with space.
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        multipart_form (decoder)          0   simple.                  │
# └──────────────────────────────────────────────────────────────────────────────┘
# ASSERT unamed values
# File "test/test.ml", line 105, character 6:
# FAIL unamed values
# 
#    Expected: `1'
#    Received: `0'
# 
# Raised at Alcotest_engine__Test.check in file "src/alcotest-engine/test.ml", lines 200-210, characters 4-19
# Called from Dune__exe__Test.simple_multipart_form.(fun) in file "test/test.ml", line 105, characters 6-60
# Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 181, characters 17-23
# Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
# 
# Logs saved to `~/.opam/5.2/.opam-switch/build/multipart_form.0.5.0/_build/default/test/_build/_tests/multipart_form/multipart_form U+0028decoderU+0029.000.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/multipart_form.0.5.0/_build/default/test/_build/_tests/multipart_form'.
# 3 failures! in 0.001s. 7 tests run.
```